### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Connect to your Elasticsearch data directly from any MCP Client (like Claude Des
 
 This server connects agents to your Elasticsearch data using the Model Context Protocol (MCP). It allows you to interact with your Elasticsearch indices through natural language conversations.
 
+<a href="https://glama.ai/mcp/servers/@elastic/mcp-server-elasticsearch">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@elastic/mcp-server-elasticsearch/badge" alt="Elasticsearch Server MCP server" />
+</a>
+
 ## Features
 
 * **List Indices**: View all available Elasticsearch indices


### PR DESCRIPTION
This PR adds a badge for the [Elasticsearch MCP Server](https://glama.ai/mcp/servers/@elastic/mcp-server-elasticsearch) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@elastic/mcp-server-elasticsearch">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@elastic/mcp-server-elasticsearch/badge" alt="Elasticsearch Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.