### PR TITLE
Add get_shards tool for monitoring shard status

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This server connects agents to your Elasticsearch data using the Model Context P
 * `list_indices`: List all available Elasticsearch indices
 * `get_mappings`: Get field mappings for a specific Elasticsearch index
 * `search`: Perform an Elasticsearch search with the provided query DSL
+* `get_shards`: Get shard information for all or specific indices
 
 ## Prerequisites
 


### PR DESCRIPTION
 Add get_shards tool for monitoring shard status

<img width="497" alt="Screenshot 2025-04-05 at 18 00 33" src="https://github.com/user-attachments/assets/34a94d6a-8dc2-44d3-a34c-455deefcee75" />

## Changes
- Add `get_shards` tool to check shard distribution and status
- Support optional index parameter for filtering
- Return detailed shard metadata (state, docs, size, node info)


## Using
<img width="762" alt="Screenshot 2025-04-05 at 18 02 48" src="https://github.com/user-attachments/assets/6042f371-3f0c-49a2-9763-b9eb7ed91c6a" />
<img width="835" alt="Screenshot 2025-04-05 at 18 01 59" src="https://github.com/user-attachments/assets/f7ad74aa-e39f-4f7f-a3f2-3a4cf39600ca" />
<img width="774" alt="Screenshot 2025-04-05 at 18 01 57" src="https://github.com/user-attachments/assets/b8a88109-9b9a-4158-a078-45e58e34b641" />