### PR TITLE
Add index pattern argument for list indices tool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -112,10 +112,19 @@ export async function createElasticsearchMcpServer(
   server.tool(
     "list_indices",
     "List all available Elasticsearch indices",
-    {},
-    async () => {
+    {
+      indexPattern: z
+        .string()
+        .trim()
+        .min(1, "Index pattern is required")
+        .describe("Index pattern of Elasticsearch indices to list"),
+    },
+    async ( {indexPattern} ) => {
       try {
-        const response = await esClient.cat.indices({ format: "json" });
+        const response = await esClient.cat.indices({ 
+          index: indexPattern, 
+          format: "json" 
+        });
 
         const indicesInfo = response.map((index) => ({
           index: index.index,


### PR DESCRIPTION
Allow the list indices tool to take in an index pattern of indices to list, instead of listing all of them all the time.

Examples:

<img width="1396" alt="Screenshot 2025-04-11 at 10 34 18 AM" src="https://github.com/user-attachments/assets/227fbe3e-a985-4b07-8f9d-0773bb9072c4" />

<img width="1402" alt="Screenshot 2025-04-11 at 10 34 09 AM" src="https://github.com/user-attachments/assets/5523231a-db7a-4acc-b18d-e28a8c53f13d" />
