### PR TITLE
feat: initialize EDOT and MCP instrumentation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import "@elastic/opentelemetry-node";
+import "./telemetry.js";
+
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client, estypes, ClientOptions } from "@elastic/elasticsearch";

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "generate-notice": "node ./scripts/generate-notice.js"
   },
   "dependencies": {
+    "@arizeai/openinference-instrumentation-mcp": "^0.2.0",
     "@elastic/elasticsearch": "^9.0.0",
+    "@elastic/opentelemetry-node": "^1.0.0",
     "@modelcontextprotocol/sdk": "1.11.2"
   },
   "engines": {

--- a/telemetry.ts
+++ b/telemetry.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MCPInstrumentation } from "@arizeai/openinference-instrumentation-mcp";
+import * as MCPServerStdioModule from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const mcpInstrumentation = new MCPInstrumentation();
+mcpInstrumentation.manuallyInstrument({
+    serverStdioModule: MCPServerStdioModule,
+});


### PR DESCRIPTION
This is just a proposal since there was an idea about enabling OTel for the MCP server. Since the repo is experimental I figured it doesn't hurt to just send the PR - it's quite small so it also doesn't hurt to close if not ready for this yet.

With this, I can get a full trace from a vercel AI client with instrumentation set up as well. Note `cat.indices` being created by the ES SDK in this server.

![image](https://github.com/user-attachments/assets/cdcec2bc-e5e6-49ad-bf1f-ced7e361e0d8)

/cc @codefromthecrypt @serenachou 

```ts
const {createOpenAI} = require('@ai-sdk/openai');
const {StdioClientTransport} = require('@modelcontextprotocol/sdk/client/stdio.js');
const {experimental_createMCPClient, extractReasoningMiddleware, generateText, wrapLanguageModel} = require('ai');

const openai = createOpenAI({
    baseURL: process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1'
});
const model = process.env.CHAT_MODEL || 'gpt-4o-mini';

/**
 * Runs the agent with the given tools.
 *
 * @param {import('ai').ToolSet} tools - The tools the LLM can use to answer the question.
 */
async function runAgent(tools) {
    const {text} = await generateText({
        // If using reasoning models, remove the format rewards from output. Non-reasoning models will not have
        // them making it effectively a no-op.
        model: wrapLanguageModel({
            model: openai(model),
            middleware: [extractReasoningMiddleware({ tagName: 'think' })],
        }),
        messages: [{role: 'user', content: "What indices do I have in my Elasticsearch cluster?"}],
        temperature: 0,
        tools,
        tool_choice: 'auto',
        maxSteps: 10,
        experimental_telemetry: {isEnabled: true},
    });

    console.log(text);
}

async function main() {
    const transport = new StdioClientTransport({
        command: "npx",
        args: ["tsx", "../../../mcp-server-elasticsearch/index.ts"],
        env: {
            PATH: process.env.PATH,
            ES_URL: "http://localhost:9200",
            ES_USERNAME: "elastic",
            ES_PASSWORD: "elastic",
            OTEL_SERVICE_NAME: "mcp-server-elasticsearch",
        },
    });
    const client = await experimental_createMCPClient({transport});
    try {
        const tools = await client.tools();
        await runAgent(tools);
    } finally {
        await client.close();
    }
}

main().catch(error => {
    console.error('Error:', error);
    process.exit(1);
});
```