### PR TITLE
doc: use env vars in Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ This server connects agents to your Elasticsearch data using the Model Context P
          "command": "docker",
          "args": [
            "run", "--rm", "-i",
-           "-e", "ES_URL=<your-elasticsearch-url>",
-           "-e", "ES_API_KEY=<your-api-key>",
+           "-e", "ES_URL",
+           "-e", "ES_API_KEY",
            "docker.elastic.co/mcp/elasticsearch", "stdio"
-         ]
+         ],
+         "env": {
+           "ES_URL": "<your-elasticsearch-url>",
+           "ES_API_KEY": "<your-api-key>"
+         }
        }
      }
    }


### PR DESCRIPTION
Follow-up to #97: use env variables in the Docker configuration doc, clearer than inlined values and more consistent with `npx` instructions.