### PR TITLE
Update README.md to include disabling otel for dev 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ The Elasticsearch MCP Server supports configuration options to connect to your E
          ],
          "env": {
            "ES_URL": "your-elasticsearch-url",
-           "ES_API_KEY": "your-api-key"
+           "ES_API_KEY": "your-api-key",
+           "OTEL_LOG_LEVEL": "none"
          }
        }
      }


### PR DESCRIPTION
You need to dissable otel to use it in e.g. claude desktop for development. When I followed the developing instructions it broke because this wasn't set