### PR TITLE
Add Buildkite job to build and publish Docker images

### DIFF
--- a/.buildkite/docker-push.sh
+++ b/.buildkite/docker-push.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+version_tag=$(jq -r ".version" ./package.json)
+elastic_image="docker.elastic.co/mcp/elasticsearch:$version_tag"
+
+# build image
+docker buildx build -t "$elastic_image" --platform linux/amd64,linux/arm64 .
+
+# push to docker.elastic.co
+ELASTIC_PASSWORD=$(vault read -field=password secret/ci/elastic-mcp-server-elasticsearch/devtoolsmachine)
+docker login -u "devtoolsmachine" -p "$ELASTIC_PASSWORD" docker.elastic.co
+docker push "$elastic_image"
+docker logout docker.elastic.co

--- a/.buildkite/docker.yml
+++ b/.buildkite/docker.yml
@@ -1,0 +1,7 @@
+---
+# $yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+steps:
+  - label: "Build and publish Docker image"
+    command: "./.buildkite/docker-push.sh"
+    agents:
+      provider: "gcp"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,4 +1,14 @@
-# Declare your Buildkite pipelines below
+---
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mcp-server-elasticsearch
+spec:
+  type: library
+  owner: group:devtools-team
+  lifecycle: beta
+
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -30,3 +40,36 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: mcp-server-elasticsearch-docker
+  description: Build and publish Docker images for mcp-server-elasticsearch
+spec:
+  type: buildkite-pipeline
+  owner: group:devtools-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: mcp-server-elasticsearch-docker
+      description: Build and publish Docker images for mcp-server-elasticsearch
+    spec:
+      repository: elastic/mcp-server-elasticsearch
+      pipeline_file: ".buildkite/docker.yml"
+      teams:
+        search-extract-and-transform:
+          access_level: MANAGE_BUILD_AND_READ
+        devtools-team:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+      provider_settings:
+        build_pull_requests: false
+        build_branches: false
+        build_tags: true
+      cancel_intermediate_builds: true


### PR DESCRIPTION
Adds all the necessary configs to build and publish Docker images to `docker.elastic.co` whenever a new release is tagged.

Not ready to merge/run until Vault secrets are in place. Working on that now.
