### PR TITLE
Github action to build binaries for all OS/arch combos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build Rust binaries
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to build (e.g. v0.4.1)
+        required: true
+        type: string
+
+jobs:
+  build-binary:
+    runs-on: ${{ matrix.os.runner }}
+    permissions:
+      contents: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - x64
+          - arm64
+        os:
+          - name: linux
+            runner: ubuntu-latest
+          - name: windows
+            runner: windows-latest
+          - name: macos
+            runner: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ inputs.version }}
+      - name: Get Rust target name
+        id: rust-target
+        env:
+          RUST_OS: ${{ matrix.os.name }}
+          RUST_ARCH: ${{ matrix.arch }}
+        run: |
+          echo target=$(.github/workflows/scripts/rust-build.sh --print-target) >> "$GITHUB_OUTPUT"
+      - name: Rust toolkit setup
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ steps.rust-target.outputs.target }}
+      - name: Build binary ${{ matrix.os.name }}-${{ matrix.arch }}
+        env:
+          RUST_OS: ${{ matrix.os.name }}
+          RUST_ARCH: ${{ matrix.arch }}
+        run: .github/workflows/scripts/rust-build.sh
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          tag: ${{ inputs.version }}
+          release_id: ${{ inputs.version }}
+          file: target/${{ steps.rust-target.outputs.target }}/release/elasticsearch-core-mcp-server
+          asset_name: elasticsearch-core-mcp-server-${{ matrix.os.name }})-${{ matrix.arch }}
+          overwrite: true

--- a/.github/workflows/scripts/rust-build.sh
+++ b/.github/workflows/scripts/rust-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+PRINT_TARGET=false
+if [[ $1 == "--print-target" ]]; then
+  PRINT_TARGET=true
+  shift
+fi
+
+# build Rust toolchain name
+if [[ "$RUST_ARCH" == "x64" ]]; then
+  ARCH="x86_64"
+elif [[ "$RUST_ARCH" == "arm64" ]]; then
+  ARCH="aarch64"
+else
+  echo "Unsupported architecture: $RUST_ARCH"
+  exit 1
+fi
+
+if [[ "$RUST_OS" == "linux" ]]; then
+  OS="unknown-linux-gnu"
+elif [[ "$RUST_OS" == "macos" ]]; then
+  OS="apple-darwin"
+elif [[ "$RUST_OS" == "windows" ]]; then
+  OS="pc-windows-msvc"
+else
+  echo "Unsupported OS: $RUST_OS"
+  exit 1
+fi
+
+RUST_TOOLCHAIN="$ARCH-$OS"
+
+if [[ "$PRINT_TARGET" == true ]]; then
+  echo "$RUST_TOOLCHAIN"
+  exit 0
+else
+  cargo build --release --target "$RUST_TOOLCHAIN"
+fi


### PR DESCRIPTION
Builds a Rust binary for each OS/architecture combination and attaches the file to the release with the specified tag.
