### PR TITLE
OS-specific tweaks for Rust builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           tag: ${{ inputs.version }}
-          file: ${{ github.workspace }}/checkout-tag/target/${{ steps.rust-target.outputs.target }}/release/elasticsearch-core-mcp-server
+          file: checkout-tag/target/${{ steps.rust-target.outputs.target }}/release/elasticsearch-core-mcp-server
           asset_name: elasticsearch-core-mcp-server.${{ inputs.version }}.${{ matrix.os.name }})-${{ matrix.arch }}
           overwrite: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           - name: macos
             runner: macos-latest
     steps:
+      - name: Install missing OS dependencies for Linux
+        if: ${{ matrix.os.name == 'linux' }}
+        run: sudo apt update && sudo apt install libssl-dev
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
- Install libssl-dev on Linux runner
- Make built Rust binary path relative to better support Windows
