### PR TITLE
Add 2nd Dockerfile for port 8000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "elasticsearch-core-mcp-server"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-core-mcp-server"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 authors = ["Elastic.co"]
 license-file = "LICENSE"
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 
 # CLI, config
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 dotenvy = "0.15"
 serde-aux = "4"
 serde_json5 = "0.2"

--- a/Dockerfile-8000
+++ b/Dockerfile-8000
@@ -1,6 +1,7 @@
 # Copyright Elasticsearch B.V. and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# Custom image to start
 # To create a multi-arch image, run:
 # docker buildx build --platform linux/amd64,linux/arm64 --tag elasticsearch-core-mcp-server .
 
@@ -23,9 +24,14 @@ RUN cargo build --release
 
 #--------------------------------------------------------------------------------------------------
 
-FROM cgr.dev/chainguard/wolfi-base:latest
+FROM debian:stable-slim
+
+RUN apt-get update && apt install -y libssl-dev && apt clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/elasticsearch-core-mcp-server /usr/local/bin/elasticsearch-core-mcp-server
 
-EXPOSE 8080/tcp
+ENV HTTP_ADDRESS="0.0.0.0:8000"
+
+EXPOSE 8000/tcp
 ENTRYPOINT ["/usr/local/bin/elasticsearch-core-mcp-server"]
+CMD ["http"]

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ cluster's API key
 The MCP server is started in http mode with this command:
 
 ```bash
-docker run --rm -e ES_URL -p 8000:8000 docker.elastic.co/mcp/elasticsearch http
+docker run --rm -e ES_URL -p 8080:8080 docker.elastic.co/mcp/elasticsearch http
 ```
 
 If for some reason your execution environment doesn't allow passing parameters to the container, they can be passed
-using the `CLI_ARGS` environment variable: `docker run --rm -e ES_URL -e CLI_ARGS=http -p 8000:8000...`
+using the `CLI_ARGS` environment variable: `docker run --rm -e ES_URL -e CLI_ARGS=http -p 8080:8080...`
 
-The streamable-HTTP endpoint is at `http:<host>:8000/mcp`. There's also a health check at `http:<host>:8000/ping`
+The streamable-HTTP endpoint is at `http:<host>:8080/mcp`. There's also a health check at `http:<host>:8080/ping`
 
 Configuration for Claude Desktop (free edition that only supports the stdio protocol).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,8 +42,8 @@ pub struct HttpCommand {
     #[clap(short, long)]
     pub config: Option<PathBuf>,
 
-    /// Address to listen to [default: 127.0.0.1:8000]
-    #[clap(long, value_name = "IP_ADDRESS:PORT")]
+    /// Address to listen to [default: 127.0.0.1:8080]
+    #[clap(long, value_name = "IP_ADDRESS:PORT", env = "HTTP_ADDRESS")]
     pub address: Option<std::net::SocketAddr>,
 
     /// Also start an SSE server on '/sse'


### PR DESCRIPTION
Prepare a dedicated Docker file for environments that need a default configuration starting in http mode on port 8000:

* revert #142 and set back the default port to `8080`
* allow http listen address to be set using the `HTTP_ADDRESS` env var
* add a new `Dockerfile-8000` docker build that defaults `HTTP_ADDRESS` to `0.0.0.0:8000` and sets the default CLI arguments to `http` (no need to use the `CLI_ARGS` workaround)
* bump version to 0.4.3