### PR TITLE
Add ca certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "elasticsearch-core-mcp-server"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-core-mcp-server"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 authors = ["Elastic.co"]
 license-file = "LICENSE"

--- a/Dockerfile-8000
+++ b/Dockerfile-8000
@@ -26,7 +26,13 @@ RUN cargo build --release
 
 FROM debian:stable-slim
 
-RUN apt-get update && apt install -y libssl-dev && apt clean && rm -rf /var/lib/apt/lists/*
+RUN <<EOF
+    apt-get clean
+    apt-get update
+    apt-get install --yes libssl-dev ca-certificates
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
 
 COPY --from=builder /app/target/release/elasticsearch-core-mcp-server /usr/local/bin/elasticsearch-core-mcp-server
 


### PR DESCRIPTION
Root certificates were missing in `Docker-8000` based on `debian:slim`.

Also bumped the revision to `0.4.4`.