### PR TITLE
Update ENV name for username

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub async fn setup_services(config: &Option<PathBuf>) -> anyhow::Result<impl Ser
             "elasticsearch": {
                 "url": "${ES_URL}",
                 "api_key": "${ES_API_KEY:}",
-                "username": "${ES_LOGIN:}",
+                "username": "${ES_USERNAME:}",
                 "password": "${ES_PASSWORD:}",
                 "ssl_skip_verify": "${ES_SSL_SKIP_VERIFY:false}"
             }


### PR DESCRIPTION
Update ES Username

According to [Readme](https://github.com/elastic/mcp-server-elasticsearch#using-the-stdio-protocol), ENV to pass username should be called `ES_USERNAME`

It could be a breaking change, so maybe readme should be updated instead