### PR TITLE
Add container-mode to rename localhost to the container host name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,6 @@ dependencies = [
  "futures-util",
  "http",
  "indexmap 2.9.0",
- "is-container",
  "itertools",
  "reqwest",
  "rmcp",
@@ -1050,15 +1049,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "is-container"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e073af786923841869a2d134062c20650026d7ed47af5cca6742459e77a20f2"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ clap = { version = "4", features = ["derive", "env"] }
 dotenvy = "0.15"
 serde-aux = "4"
 serde_json5 = "0.2"
-is-container = "0.1.2"
 
 # Logging
 tracing = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 
 # Cache dependencies
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target \
-    mkdir -p ./src/bin && \
+RUN mkdir -p ./src/bin && \
     echo "pub fn main() {}" > ./src/bin/elasticsearch-core-mcp-server.rs && \
     cargo build --release
 
@@ -26,6 +24,8 @@ RUN cargo build --release
 FROM cgr.dev/chainguard/wolfi-base:latest
 
 COPY --from=builder /app/target/release/elasticsearch-core-mcp-server /usr/local/bin/elasticsearch-core-mcp-server
+
+ENV CONTAINER_MODE=true
 
 EXPOSE 8080/tcp
 ENTRYPOINT ["/usr/local/bin/elasticsearch-core-mcp-server"]

--- a/Dockerfile-8000
+++ b/Dockerfile-8000
@@ -12,9 +12,7 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 
 # Cache dependencies
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/app/target \
-    mkdir -p ./src/bin && \
+RUN mkdir -p ./src/bin && \
     echo "pub fn main() {}" > ./src/bin/elasticsearch-core-mcp-server.rs && \
     cargo build --release
 
@@ -36,6 +34,7 @@ EOF
 
 COPY --from=builder /app/target/release/elasticsearch-core-mcp-server /usr/local/bin/elasticsearch-core-mcp-server
 
+ENV CONTAINER_MODE=true
 ENV HTTP_ADDRESS="0.0.0.0:8000"
 
 EXPOSE 8000/tcp

--- a/src/bin/start_http.rs
+++ b/src/bin/start_http.rs
@@ -28,7 +28,8 @@ pub async fn main() -> anyhow::Result<()> {
         config: Some("elastic-mcp.json5".parse()?),
         address: None,
         sse: true,
-    })
+    },
+    false)
     .await?;
 
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,10 @@ use std::path::PathBuf;
 /// Elastic MCP server
 #[derive(Debug, Parser)]
 pub struct Cli {
+    /// Container mode: change default http address, rewrite localhost to the host's address
+    #[clap(global=true, long, env = "CONTAINER_MODE")]
+    pub container_mode: bool,
+
     #[clap(subcommand)]
     pub command: Command,
 }
@@ -51,7 +55,7 @@ pub struct HttpCommand {
     pub sse: bool,
 }
 
-/// Start a stdio server
+/// Start an stdio server
 #[derive(Debug, Args)]
 pub struct StdioCommand {
     /// Config file

--- a/tests/http_tests.rs
+++ b/tests/http_tests.rs
@@ -36,6 +36,7 @@ async fn http_tool_list() -> anyhow::Result<()> {
     let addr = find_address()?;
 
     let cli = cli::Cli {
+        container_mode: false,
         command: cli::Command::Http(cli::HttpCommand {
             config: None,
             address: Some(addr),
@@ -116,6 +117,7 @@ async fn end_to_end() -> anyhow::Result<()> {
     // Start an http MCP server
     let addr = find_address()?;
     let cli = cli::Cli {
+        container_mode: false,
         command: cli::Command::Http(cli::HttpCommand {
             config: None,
             address: Some(addr),


### PR DESCRIPTION
Fixes #165

Introduces a new `--container-mode` CLI flag, with the associated `CONTAINER_MODE` environment variable.

It's meant to enable some default values and behaviors that are more suited/needed when running in a container:
- change the default listen address from `127.0.0.1` to `0.0.0.0` (this was done previously automatically with the `in_container` crate)
- rewrite ES_URL containing `localhost` to the hostname of the container host (`host.docker.internal` for Docker, `host.containers.internal` for Podman, more can be added in the future).

The `Dockerfile`s have also been updated to have `ENV CONTAINER_MODE=true`

Also updates the Dockerfile's dependency caching so that it actually works 😅 