### PR TITLE
feat: add configurable timeout parameter to search and esql tools

### DIFF
--- a/src/bin/elasticsearch-core-mcp-server.rs
+++ b/src/bin/elasticsearch-core-mcp-server.rs
@@ -15,15 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::io::ErrorKind;
 use clap::Parser;
 use elasticsearch_core_mcp_server::cli::Cli;
+use std::io::ErrorKind;
 use tracing_subscriber::EnvFilter;
 // To test with stdio, use npx @modelcontextprotocol/inspector cargo run -p elastic-mcp
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-
     // Also accept .env files
     match dotenvy::dotenv() {
         Err(dotenvy::Error::Io(io_err)) if io_err.kind() == ErrorKind::NotFound => {}

--- a/src/bin/start_http.rs
+++ b/src/bin/start_http.rs
@@ -24,12 +24,14 @@ use elasticsearch_core_mcp_server::run_http;
 pub async fn main() -> anyhow::Result<()> {
     println!("Current directory: {:?}", std::env::current_dir()?);
 
-    run_http(HttpCommand {
-        config: Some("elastic-mcp.json5".parse()?),
-        address: None,
-        sse: true,
-    },
-    false)
+    run_http(
+        HttpCommand {
+            config: Some("elastic-mcp.json5".parse()?),
+            address: None,
+            sse: true,
+        },
+        false,
+    )
     .await?;
 
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 #[command(version)]
 pub struct Cli {
     /// Container mode: change default http address, rewrite localhost to the host's address
-    #[clap(global=true, long, env = "CONTAINER_MODE")]
+    #[clap(global = true, long, env = "CONTAINER_MODE")]
     pub container_mode: bool,
 
     #[clap(subcommand)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,10 @@ pub async fn run_http(cmd: HttpCommand, container_mode: bool) -> anyhow::Result<
     Ok(())
 }
 
-pub async fn setup_services(config: &Option<PathBuf>, container_mode: bool) -> anyhow::Result<impl Service<RoleServer> + Clone> {
+pub async fn setup_services(
+    config: &Option<PathBuf>,
+    container_mode: bool,
+) -> anyhow::Result<impl Service<RoleServer> + Clone> {
     // Read config file and expand variables
 
     let config = if let Some(path) = config {

--- a/src/servers/elasticsearch/mod.rs
+++ b/src/servers/elasticsearch/mod.rs
@@ -175,7 +175,10 @@ pub enum SearchTemplate {
 pub struct ElasticsearchMcp {}
 
 impl ElasticsearchMcp {
-    pub fn new_with_config(config: ElasticsearchMcpConfig, container_mode: bool) -> anyhow::Result<base_tools::EsBaseTools> {
+    pub fn new_with_config(
+        config: ElasticsearchMcpConfig,
+        container_mode: bool,
+    ) -> anyhow::Result<base_tools::EsBaseTools> {
         let creds = if let Some(api_key) = config.api_key.clone() {
             Some(Credentials::EncodedApiKey(api_key))
         } else if let Some(username) = config.username.clone() {
@@ -224,13 +227,17 @@ impl ElasticsearchMcp {
 fn rewrite_localhost(url: &mut Url) -> anyhow::Result<()> {
     use std::net::ToSocketAddrs;
     let aliases = &[
-        "host.docker.internal", // Docker
+        "host.docker.internal",     // Docker
         "host.containers.internal", // Podman, maybe others
     ];
 
-    if let Some(host) = url.host_str() && host == "localhost" {
+    if let Some(host) = url.host_str()
+        && host == "localhost"
+    {
         for alias in aliases {
-            if let Ok(mut alias_add) = (*alias, 80).to_socket_addrs() && alias_add.next().is_some() {
+            if let Ok(mut alias_add) = (*alias, 80).to_socket_addrs()
+                && alias_add.next().is_some()
+            {
                 url.set_host(Some(alias))?;
                 tracing::info!("Container mode: using '{alias}' instead of 'localhost'");
                 return Ok(());


### PR DESCRIPTION
## Summary

Adds an optional `timeout` parameter to the `search` and `esql` tools, allowing LLMs to specify query timeouts using Elasticsearch time units (e.g., `"30s"`, `"2m"`, `"1m30s"`).

## Motivation

Queries can run indefinitely without timeout controls, which can cause:
- Resource exhaustion on Elasticsearch clusters
- Poor user experience with hanging requests
- Difficulty managing long-running queries

## Changes

- Added optional `timeout` parameter to `SearchParams` with default value of `"120s"`
- Added optional `timeout` parameter to `EsqlQueryParams` with default value of `"120s"`
- For `search`: uses `.timeout()` method on the Elasticsearch search API
- For `esql`: uses `query_timeout` in the ES|QL request body
- Includes code formatting changes from `cargo fmt`

## Testing

- ✅ All existing tests pass
- ✅ `cargo clippy` passes with no warnings
- ✅ Code formatted with `cargo fmt`
- ✅ Docker image builds successfully

## Example Usage

```json
{
  "name": "search",
  "arguments": {
    "index": "my-index",
    "query_body": {"query": {"match_all": {}}},
    "timeout": "30s"
  }
}
```

The timeout parameter accepts Elasticsearch time unit format and defaults to 120 seconds if not specified.