### PR TITLE
docs: add GitHub Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ The configuration for Claude Desktop is as follows:
 }
 ```
 
+#### GitHub Copilot CLI
+
+Use the Copilot CLI to interactively add the MCP server:
+
+```bash
+/mcp add
+```
+
+Alternatively, create or edit `~/.copilot/mcp-config.json` and add:
+
+```json
+{
+  "mcpServers": {
+    "elasticsearch-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "ES_URL", "-e", "ES_API_KEY",
+        "docker.elastic.co/mcp/elasticsearch",
+        "stdio"
+      ],
+      "env": {
+        "ES_URL": "<elasticsearch-cluster-url>",
+        "ES_API_KEY": "<elasticsearch-API-key>"
+      }
+    }
+  }
+}
+```
+
+For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+
 ### Using the streamable-HTTP and SSE protocols
 
 Note: streamable-HTTP is recommended, as [SSE is deprecated](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse-deprecated).


### PR DESCRIPTION
Adds GitHub Copilot CLI installation instructions to the README, following the existing pattern for Claude Desktop.

The configuration uses the same Docker command and environment variables as the existing Claude Desktop example.

## Changes

- Added "GitHub Copilot CLI" section under the stdio protocol configuration
- Includes interactive setup (`/mcp add`) and manual configuration options
- Uses the same server name, Docker image, and env vars as existing examples