### PR TITLE
feat: add gemini-extension.json to support Gemini CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ The configuration for Claude Desktop is as follows:
 }
 ```
 
+### Using with Gemini CLI
+
+You can seamlessly install and configure the Elasticsearch MCP server using the Gemini CLI.
+
+```bash
+gemini extensions install [https://github.com/elastic/mcp-server-elasticsearch](https://github.com/elastic/mcp-server-elasticsearch)
+
+```
 ### Using the streamable-HTTP and SSE protocols
 
 Note: streamable-HTTP is recommended, as [SSE is deprecated](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse-deprecated).

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The configuration for Claude Desktop is as follows:
 
 ### Using with Gemini CLI
 
-You can seamlessly install and configure the Elasticsearch MCP server using the Gemini CLI.
+You can seamlessly install and configure the Elasticsearch MCP server using the latest Gemini CLI.
 
 ```bash
 gemini extensions install [https://github.com/elastic/mcp-server-elasticsearch](https://github.com/elastic/mcp-server-elasticsearch)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,59 @@
+{
+  "name": "elasticsearch",
+  "version": "1.0.0",
+  "description": "Elasticsearch MCP Server for interacting with your Elasticsearch data via natural language.",
+  "settings": [
+    {
+      "name": "Elasticsearch URL",
+      "description": "The URL of your Elasticsearch cluster (e.g., http://localhost:9200).",
+      "envVar": "ES_URL",
+      "sensitive": false
+    },
+    {
+      "name": "Elasticsearch API Key",
+      "description": "API key for authentication (optional if using username/password).",
+      "envVar": "ES_API_KEY",
+      "sensitive": true
+    },
+    {
+      "name": "Elasticsearch Username",
+      "description": "Username for basic authentication (optional if using API key).",
+      "envVar": "ES_USERNAME",
+      "sensitive": false
+    },
+    {
+      "name": "Elasticsearch Password",
+      "description": "Password for basic authentication (optional if using API key).",
+      "envVar": "ES_PASSWORD",
+      "sensitive": true
+    },
+    {
+      "name": "Skip SSL Verification",
+      "description": "Set to 'true' to skip SSL/TLS certificate verification.",
+      "envVar": "ES_SSL_SKIP_VERIFY",
+      "sensitive": false
+    }
+  ],
+  "mcpServers": {
+    "elasticsearch-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "ES_URL",
+        "-e",
+        "ES_API_KEY",
+        "-e",
+        "ES_USERNAME",
+        "-e",
+        "ES_PASSWORD",
+        "-e",
+        "ES_SSL_SKIP_VERIFY",
+        "docker.elastic.co/mcp/elasticsearch",
+        "stdio"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR introduces a gemini-extension.json manifest to the repository root and updates the README.md to enable seamless, 1-click installation of the Elasticsearch MCP server via the Gemini CLI.

## Motivation
By utilizing the Gemini CLI's settings schema, users no longer need to manually manage plain-text environment variables. During installation, the CLI interactively prompts the user for their connection details (e.g., ES_URL, ES_API_KEY) and stores them securely in the system keychain.

Because this server is distributed as a Docker image, the manifest is configured to automatically pass these securely stored environment variables into the docker run command, completely abstracting the manual configuration away from the end-user.

## Changes Included

Added gemini-extension.json mapping the required environment variables to the docker run execution block.

Added a short "Using with Gemini CLI" section to README.md.

## Testing
Users can now install and configure the server simply by running:
gemini extensions install https://github.com/elastic/mcp-server-elasticsearch